### PR TITLE
fix: `libc++` in bazel rbe

### DIFF
--- a/containers/rbe/Dockerfile
+++ b/containers/rbe/Dockerfile
@@ -24,6 +24,7 @@ RUN --security=sandbox echo "Installing packages..." \
       tclsh \
       build-essential \
       linux-headers-$(uname -r) \
+      libc++-dev \
     && apt-get autoremove \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Name's on the tin