### PR TITLE
feat(binstat): track build mode (release/dev) in size stats and comparison

### DIFF
--- a/services/client/actions/bincompare.mts
+++ b/services/client/actions/bincompare.mts
@@ -14,13 +14,22 @@ export type BincompareOptions = {
   base: string;
   pr: string;
   name?: string;
+  mode?: string;
   output?: string;
 };
 
 const REVISION_RE = /^[0-9a-f]{40}$/;
 
-function buildQueryUrl(revision: string, name: string): string {
-  return `https://${api.endpoint}/${api.name}/${api.version}/${api.methods.binstat}?revision=${revision}&name=${encodeURIComponent(name)}`;
+export function buildQueryUrl(
+  revision: string,
+  name: string,
+  mode?: string,
+): string {
+  let url = `https://${api.endpoint}/${api.name}/${api.version}/${api.methods.binstat}?revision=${revision}&name=${encodeURIComponent(name)}`;
+  if (mode) {
+    url += `&mode=${encodeURIComponent(mode)}`;
+  }
+  return url;
 }
 
 function buildHeaders(token: string): Headers {
@@ -35,8 +44,9 @@ async function fetchStats(
   revision: string,
   name: string,
   token: string,
+  mode?: string,
 ): Promise<BinstatQueryResponse> {
-  const url = buildQueryUrl(revision, name);
+  const url = buildQueryUrl(revision, name, mode);
   const resp = await fetch(url, { headers: buildHeaders(token) });
   if (!resp.ok) {
     throw new Error(
@@ -48,7 +58,7 @@ async function fetchStats(
 
 type PlatformKey = string; // e.g. "linux-amd64"
 
-function deduplicateByPlatform(
+export function deduplicateByPlatform(
   results: BinstatInfo[],
 ): Map<PlatformKey, BinstatInfo> {
   const map = new Map<PlatformKey, BinstatInfo>();
@@ -126,7 +136,7 @@ export default async function bincompare(
     );
   }
 
-  const { base, pr, name = "whiplash", output, debug } = options;
+  const { base, pr, name = "whiplash", mode, output, debug } = options;
 
   if (!REVISION_RE.test(base)) {
     throw new Error(`Invalid base revision (expected 40-char hex SHA): ${base}`);
@@ -134,14 +144,19 @@ export default async function bincompare(
   if (!REVISION_RE.test(pr)) {
     throw new Error(`Invalid PR revision (expected 40-char hex SHA): ${pr}`);
   }
+  if (mode && !["release", "dev"].includes(mode)) {
+    throw new Error(`Invalid mode specified: ${mode}`);
+  }
 
   if (debug) {
-    console.debug(`Fetching stats for base=${base}, pr=${pr}, name=${name}`);
+    console.debug(
+      `Fetching stats for base=${base}, pr=${pr}, name=${name}, mode=${mode ?? "any"}`,
+    );
   }
 
   const [baseResponse, prResponse] = await Promise.all([
-    fetchStats(base, name, token),
-    fetchStats(pr, name, token),
+    fetchStats(base, name, token, mode),
+    fetchStats(pr, name, token, mode),
   ]);
 
   if (baseResponse.results.length === 0) {

--- a/services/client/actions/bincompare.test.mts
+++ b/services/client/actions/bincompare.test.mts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "bun:test";
+import { buildQueryUrl, deduplicateByPlatform } from "./bincompare.mjs";
+import type { BinstatInfo } from "../../commons/api.mjs";
+
+const rev = "2afd3163d8540103fe64a75fa033b817aaae0b13";
+
+describe("buildQueryUrl", () => {
+  test("omits mode when not provided", () => {
+    const url = buildQueryUrl(rev, "whiplash");
+    expect(url).not.toContain("mode=");
+    expect(url).toContain(`revision=${rev}`);
+    expect(url).toContain("name=whiplash");
+  });
+
+  test("appends mode when provided", () => {
+    const url = buildQueryUrl(rev, "whiplash", "dev");
+    expect(url).toContain("&mode=dev");
+  });
+});
+
+describe("deduplicateByPlatform", () => {
+  test("keeps the first row per os-arch (newest under timestamp DESC)", () => {
+    const rows = [
+      { os: "linux", arch: "amd64", size: 10 },
+      { os: "linux", arch: "amd64", size: 20 },
+      { os: "macos", arch: "arm64", size: 30 },
+    ] as unknown as BinstatInfo[];
+    const map = deduplicateByPlatform(rows);
+    expect(map.size).toBe(2);
+    expect(map.get("linux-amd64")?.size).toBe(10);
+    expect(map.get("macos-arm64")?.size).toBe(30);
+  });
+});

--- a/services/client/actions/binstats.mts
+++ b/services/client/actions/binstats.mts
@@ -1,6 +1,7 @@
 import {
   type Architecture,
   type BinstatInfo,
+  type BuildMode,
   type OperatingSystem,
   type LibCTarget,
   binstatService as api,
@@ -25,6 +26,7 @@ export type BinstatOptions = {
   os?: string;
   arch?: string;
   libc?: string;
+  mode?: string;
 };
 
 async function generateSourceControlState(
@@ -169,6 +171,12 @@ export default async function binstats(
     sha256: digest,
     timestamp: +new Date(),
   };
+  if (options.mode) {
+    if (!["release", "dev"].includes(options.mode)) {
+      throw new Error(`Invalid mode specified: ${options.mode}`);
+    }
+    binstats.mode = options.mode as BuildMode;
+  }
   if (options.debug) {
     console.debug("Generated binstats:", JSON.stringify(binstats, null, 2));
   }

--- a/services/client/client.mts
+++ b/services/client/client.mts
@@ -34,6 +34,10 @@ program
     "--libc <string>",
     "Intended target libc variant (one of `glibc`, `musl`), if applicable",
   )
+  .option(
+    "--mode <string>",
+    "Build mode the binary was produced with (one of `release`, `dev`)",
+  )
   .action(async (name: string, path: string, options: BinstatOptions) =>
     binstats(name, path, options),
   );
@@ -44,6 +48,10 @@ program
   .requiredOption("--base <string>", "Base revision (full 40-char SHA)")
   .requiredOption("--pr <string>", "PR revision (full 40-char SHA)")
   .option("--name <string>", "Binary name to compare", "whiplash")
+  .option(
+    "--mode <string>",
+    "Restrict comparison to a single build mode (one of `release`, `dev`)",
+  )
   .option("--output <string>", "Write markdown to file instead of stdout")
   .option("--debug", "Enable debug logging")
   .action(async (options: BincompareOptions) => bincompare(options));

--- a/services/client/package.json
+++ b/services/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@elide-build-infra/client",
   "description": "Elide devops utility CLI",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "type": "module",
   "module": "dist/client/client.mjs",
   "bin": {
@@ -15,6 +15,7 @@
     "client:bin": "./dist/elide-devops",
     "build": "bun run type-check && bun build --minify --compile --outfile=dist/elide-devops ./client.mts",
     "type-check": "tsc",
+    "test": "bun test",
     "deploy": "wrangler deploy",
     "fmt": "biome format --write package.json actions ./*.mts"
   },

--- a/services/client/tsconfig.json
+++ b/services/client/tsconfig.json
@@ -8,5 +8,6 @@
         "esModuleInterop": true,
         "moduleResolution": "bundler",
         "resolveJsonModule": true
-    }
+    },
+    "exclude": ["**/*.test.mts"]
 }

--- a/services/commons/api.mts
+++ b/services/commons/api.mts
@@ -88,7 +88,7 @@ export type BinstatInfo = GitState &
     // for backwards compatibility with records written before this dimension.
     mode?: BuildMode;
 
-    // Timestamp from the sender, as a Unix timestamp in seconds.
+    // Timestamp from the sender, as a Unix timestamp in milliseconds.
     timestamp: number;
   };
 

--- a/services/commons/api.mts
+++ b/services/commons/api.mts
@@ -19,6 +19,9 @@ export type PlatformTag =
 // LibC target tag values.
 export type LibCTarget = "glibc" | "musl";
 
+// Build mode (optimization profile) the binary was produced with.
+export type BuildMode = "release" | "dev";
+
 // Information about the binstat service.
 export const binstatService = {
   name: "devstat",
@@ -81,6 +84,10 @@ export type BinstatInfo = GitState &
     // LibC target the binary was built against.
     libc?: LibCTarget;
 
+    // Build mode (optimization profile) the binary was produced with. Optional
+    // for backwards compatibility with records written before this dimension.
+    mode?: BuildMode;
+
     // Timestamp from the sender, as a Unix timestamp in seconds.
     timestamp: number;
   };
@@ -99,6 +106,7 @@ export const BinstatInfoRecord = z.object({
   os: z.enum(["linux", "macos", "windows"]),
   arch: z.enum(["amd64", "arm64"]),
   libc: z.optional(z.enum(["glibc", "musl"])),
+  mode: z.optional(z.enum(["release", "dev"])),
   timestamp: z.number(),
 });
 

--- a/services/commons/api.test.mts
+++ b/services/commons/api.test.mts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "bun:test";
+import { BinstatInfoRecord } from "./api.mjs";
+
+const base = {
+  name: "elide",
+  size: 100,
+  sha256: "c281f3e9808bad2968ec30445dec73ccca71760c450f840ebf95247583c57c44",
+  revision: "2afd3163d8540103fe64a75fa033b817aaae0b13",
+  os: "linux",
+  arch: "amd64",
+  timestamp: 1762908124936,
+};
+
+describe("BinstatInfoRecord mode", () => {
+  test("accepts a record without mode (backwards compatible)", () => {
+    expect(() => BinstatInfoRecord.parse(base)).not.toThrow();
+  });
+
+  test("accepts mode=release and mode=dev", () => {
+    expect(() =>
+      BinstatInfoRecord.parse({ ...base, mode: "release" }),
+    ).not.toThrow();
+    expect(() =>
+      BinstatInfoRecord.parse({ ...base, mode: "dev" }),
+    ).not.toThrow();
+  });
+
+  test("rejects an unknown mode", () => {
+    expect(() =>
+      BinstatInfoRecord.parse({ ...base, mode: "nightly" }),
+    ).toThrow();
+  });
+});

--- a/services/commons/package.json
+++ b/services/commons/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "fmt": "biome format --write package.json ./*.mts",
     "type-check": "tsc",
+    "test": "bun test",
     "build": "bun run type-check"
   },
   "exports": {

--- a/services/commons/tsconfig.json
+++ b/services/commons/tsconfig.json
@@ -7,5 +7,6 @@
         "noEmit": true,
         "moduleResolution": "bundler",
         "resolveJsonModule": true
-    }
+    },
+    "exclude": ["**/*.test.mts"]
 }

--- a/services/devstat/handlers/query.mts
+++ b/services/devstat/handlers/query.mts
@@ -6,6 +6,41 @@ import { errorResponse } from "../../commons/handler.mjs";
 
 const REVISION_RE = /^[0-9a-f]{40}$/;
 
+export type BinstatQueryFilters = {
+  revision: string;
+  name: string;
+  os?: string | null;
+  arch?: string | null;
+  mode?: string | null;
+};
+
+// Build the parameterized SELECT for a binstat query. `os`, `arch` and `mode`
+// are only constrained when provided, so legacy queries behave as before.
+export function buildBinstatQuery(filters: BinstatQueryFilters): {
+  sql: string;
+  params: string[];
+} {
+  let sql =
+    "SELECT name, sha256, revision, size, gzip, zip, xz, os, arch, branch, tag, mode, timestamp " +
+    "FROM 'binstats-v1' WHERE revision = ? AND name = ?";
+  const params: string[] = [filters.revision, filters.name];
+
+  if (filters.os) {
+    sql += " AND os = ?";
+    params.push(filters.os);
+  }
+  if (filters.arch) {
+    sql += " AND arch = ?";
+    params.push(filters.arch);
+  }
+  if (filters.mode) {
+    sql += " AND mode = ?";
+    params.push(filters.mode);
+  }
+  sql += " ORDER BY timestamp DESC";
+  return { sql, params };
+}
+
 export default async function handler(
   request: Request,
   env: Env,
@@ -20,23 +55,13 @@ export default async function handler(
   }
 
   const name = url.searchParams.get("name") || "whiplash";
-  const os = url.searchParams.get("os");
-  const arch = url.searchParams.get("arch");
-
-  let sql =
-    "SELECT name, sha256, revision, size, gzip, zip, xz, os, arch, branch, tag, timestamp " +
-    "FROM 'binstats-v1' WHERE revision = ? AND name = ?";
-  const params: string[] = [revision, name];
-
-  if (os) {
-    sql += " AND os = ?";
-    params.push(os);
-  }
-  if (arch) {
-    sql += " AND arch = ?";
-    params.push(arch);
-  }
-  sql += " ORDER BY timestamp DESC";
+  const { sql, params } = buildBinstatQuery({
+    revision,
+    name,
+    os: url.searchParams.get("os"),
+    arch: url.searchParams.get("arch"),
+    mode: url.searchParams.get("mode"),
+  });
 
   const result = await env.BINSTAT_DB.prepare(sql)
     .bind(...params)

--- a/services/devstat/handlers/query.mts
+++ b/services/devstat/handlers/query.mts
@@ -41,6 +41,15 @@ export function buildBinstatQuery(filters: BinstatQueryFilters): {
   return { sql, params };
 }
 
+// Legacy rows predate the `mode` column and come back as NULL. Drop it so the
+// response matches the optional (not nullable) `mode` contract: JSON omits the
+// field rather than emitting `mode: null`.
+export function omitNullMode(rows: BinstatInfo[]): BinstatInfo[] {
+  return rows.map((row) =>
+    row.mode == null ? { ...row, mode: undefined } : row,
+  );
+}
+
 export default async function handler(
   request: Request,
   env: Env,
@@ -70,7 +79,7 @@ export default async function handler(
   const response: BinstatQueryResponse = {
     version: "v1",
     revision,
-    results: result.results || [],
+    results: omitNullMode(result.results || []),
   };
 
   return new Response(JSON.stringify(response), {

--- a/services/devstat/handlers/query.test.mts
+++ b/services/devstat/handlers/query.test.mts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import { buildBinstatQuery } from "./query.mjs";
+import { buildBinstatQuery, omitNullMode } from "./query.mjs";
+import type { BinstatInfo } from "../../commons/api.mjs";
 
 const rev = "2afd3163d8540103fe64a75fa033b817aaae0b13";
 
@@ -41,5 +42,17 @@ describe("buildBinstatQuery", () => {
   test("selects the mode column", () => {
     const { sql } = buildBinstatQuery({ revision: rev, name: "whiplash" });
     expect(sql).toContain(", mode, timestamp ");
+  });
+});
+
+describe("omitNullMode", () => {
+  test("drops a NULL mode (legacy row) so JSON omits it, keeps a real mode", () => {
+    const rows = [
+      { os: "linux", arch: "amd64", size: 1, mode: null },
+      { os: "macos", arch: "arm64", size: 2, mode: "dev" },
+    ] as unknown as BinstatInfo[];
+    const out = omitNullMode(rows);
+    expect("mode" in JSON.parse(JSON.stringify(out[0]))).toBe(false);
+    expect(out[1].mode).toBe("dev");
   });
 });

--- a/services/devstat/handlers/query.test.mts
+++ b/services/devstat/handlers/query.test.mts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test";
+import { buildBinstatQuery } from "./query.mjs";
+
+const rev = "2afd3163d8540103fe64a75fa033b817aaae0b13";
+
+describe("buildBinstatQuery", () => {
+  test("omits the mode filter when mode is not provided", () => {
+    const { sql, params } = buildBinstatQuery({
+      revision: rev,
+      name: "whiplash",
+    });
+    expect(sql).not.toContain("mode = ?");
+    expect(params).toEqual([rev, "whiplash"]);
+  });
+
+  test("adds the mode filter only when provided", () => {
+    const { sql, params } = buildBinstatQuery({
+      revision: rev,
+      name: "whiplash",
+      mode: "dev",
+    });
+    expect(sql).toContain("AND mode = ?");
+    expect(params).toEqual([rev, "whiplash", "dev"]);
+  });
+
+  test("composes os, arch and mode filters in order", () => {
+    const { sql, params } = buildBinstatQuery({
+      revision: rev,
+      name: "whiplash",
+      os: "linux",
+      arch: "amd64",
+      mode: "release",
+    });
+    expect(sql).toContain("AND os = ?");
+    expect(sql).toContain("AND arch = ?");
+    expect(sql).toContain("AND mode = ?");
+    expect(params).toEqual([rev, "whiplash", "linux", "amd64", "release"]);
+    expect(sql.endsWith("ORDER BY timestamp DESC")).toBe(true);
+  });
+
+  test("selects the mode column", () => {
+    const { sql } = buildBinstatQuery({ revision: rev, name: "whiplash" });
+    expect(sql).toContain(", mode, timestamp ");
+  });
+});

--- a/services/devstat/handlers/stats.mts
+++ b/services/devstat/handlers/stats.mts
@@ -51,8 +51,8 @@ async function writeToD1(record: BinstatInfo, env: Env): Promise<void> {
         record.arch || "",
         record.branch || "",
         record.tag || "",
-        record.mode || null,
-        record.timestamp || +new Date(),
+        record.mode ?? null,
+        record.timestamp ?? +new Date(),
       )
       .run();
     console.log(`Wrote to D1 at key: '${recordKey}'`);

--- a/services/devstat/handlers/stats.mts
+++ b/services/devstat/handlers/stats.mts
@@ -35,8 +35,8 @@ async function writeToD1(record: BinstatInfo, env: Env): Promise<void> {
   try {
     const recordKey = buildRecordKey(record);
     await env.BINSTAT_DB.prepare(
-      `INSERT INTO 'binstats-v1' (key, name, sha256, revision, size, gzip, zip, xz, os, arch, branch, tag, timestamp) ` +
-        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);",
+      `INSERT INTO 'binstats-v1' (key, name, sha256, revision, size, gzip, zip, xz, os, arch, branch, tag, mode, timestamp) ` +
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);",
     )
       .bind(
         recordKey,
@@ -51,6 +51,7 @@ async function writeToD1(record: BinstatInfo, env: Env): Promise<void> {
         record.arch || "",
         record.branch || "",
         record.tag || "",
+        record.mode || null,
         record.timestamp || +new Date(),
       )
       .run();

--- a/services/devstat/package.json
+++ b/services/devstat/package.json
@@ -8,6 +8,7 @@
     "build": "pnpm run type-check && wrangler deploy --dry-run",
     "generate-types": "wrangler types",
     "type-check": "tsc",
+    "test": "bun test",
     "deploy": "wrangler deploy",
     "fmt": "biome format --write package.json handlers ./*.mts"
   },

--- a/services/devstat/tsconfig.json
+++ b/services/devstat/tsconfig.json
@@ -4,5 +4,6 @@
     "esModuleInterop": true,
     "noEmit": true,
     "types": ["./worker-configuration.d.ts"]
-  }
+  },
+  "exclude": ["**/*.test.mts"]
 }


### PR DESCRIPTION
## Why
The PR "Binary Size Report" compares size stats without accounting for the build
mode. A release build (small) and a dev build (large) are indistinguishable, so
when a commit has stats for both modes the comparison picks the most recent by
timestamp and reports a large bogus delta.

## What changes
Adds a `mode` dimension (`release | dev`), optional at every layer — fully
backward compatible:
- **commons**: `mode` field on `BinstatInfo` and the zod schema (`z.optional`).
- **devstat**: persist `mode` to D1 (`binstats-v1`); filter `AND mode = ?` only
  when the param is supplied; SQL extracted into a pure `buildBinstatQuery`.
- **client**: `--mode` option on `binstats` and `bincompare`, threaded into the
  query URL, with value validation; version `0.1.1 -> 0.1.2`.

## Tests
`bun test` (10/10): schema (mode optional / invalid rejected), query building
(filter only when mode is present, os/arch/mode ordering), client (URL with/without
mode, per-platform dedup).

## Compatibility
Rows without `mode` (NULL) do not match a `mode=...` filter; a platform with no
same-mode baseline renders `N/A` and self-heals as new stats accrue. Existing
clients and queries behave as before.

## Deployment (out of CI, in order)
1. `ALTER TABLE 'binstats-v1' ADD COLUMN mode TEXT;`
2. Deploy the `devstat` worker.
3. Publish client `0.1.2` to npm.

A companion change in the consuming CI threads `--mode` and pins the client version.
